### PR TITLE
[HPCTM-1850] Correct the script for prefixing hoc files

### DIFF
--- a/model_manager.py
+++ b/model_manager.py
@@ -135,7 +135,7 @@ def copy_patch_hoc(prefix):
     basename = os.path.basename
     name_re = re.compile(r"(begin|end)template *(.*)")
     name_options = "|".join(HOC_NAMES_PREFIX)
-    pp_call_re = re.compile(rf"new *({name_options}) ?\(")
+    pp_call_re = re.compile(rf"({name_options}) ?\(")
 
     def copy_f(hoc_f, dst_dir):
         """Rename and adapt the hoc file for the new mods"""


### PR DESCRIPTION
For HPCTM-1850, we built multi-models using the script
```
./model_manager.py model_config.json --only-synapses
```
However, in the generated prefixed synapse helper file, e.g. `build/ALL/hoc/THA_AMPANMDAHelper.hoc`:
The instantiation of the synapse obj misses the `new` keyword which won't work in the simulation.
```
42     synapse = THA_ProbAMPANMDA_EMS(x)
```
This PR is correcting the script so that the `new` keyword is kept in the generated hoc files.